### PR TITLE
NameError: name 'urwid' is not defined in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,9 @@ from setuptools import setup
 
 import os
 
-import speedometer
-release = speedometer.__version__
-
 setup_d = {
     'name': "Speedometer",
-    'version': release,
+    'version': '2.9',
     'author': "Ian Ward",
     'author_email': "ian@excess.org",
     'url': "http://excess.org/speedometer/",

--- a/speedometer.py
+++ b/speedometer.py
@@ -13,14 +13,15 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
 
-__version__ = "2.9"
-
 import time
 import sys
 import os
 import string
 import math
 import re
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution('speedometer').version
 
 __usage__ = """Usage: speedometer [options] tap [[-c] tap]...
 Monitor network traffic or speed/progress of a file transfer.  At least one


### PR DESCRIPTION
If _urwid_ is not yet installed when running `setup.py`, the following exception is raised:

```
Traceback (most recent call last):
  File "setup.py", line 25, in <module>
    import speedometer
  File "/home/dustin/src/speedometer/speedometer.py", line 302, in <module>
    class GraphDisplay(urwid.WidgetWrap):
NameError: name 'urwid' is not defined
```

It is best not to rely on code being functional when `setup.py` is run. The `pkg_resources` module from setuptools provides an API for version discovery, which will do what you want in this case. I've made the necessary changes to `setup.py` and `speedometer.py` to fix this problem while still avoiding redundant version specifications.
