### PR TITLE
Autodetect network interfaces if no taps were specified

### DIFF
--- a/speedometer.py
+++ b/speedometer.py
@@ -1001,6 +1001,10 @@ def parse_args():
         raise ArgumentError
 
     push_tap(tap, taps)
+
+    if not taps:
+        autodetect_taps(taps)
+
     if not urwid_ui and (len(taps)>1 or cols):
         raise ArgumentError
 
@@ -1013,6 +1017,20 @@ def parse_args():
 
     return cols, urwid_ui, zero_files, exit_on_complete, num_colors, shiny_colors
 
+def autodetect_taps(taps):
+    print("no taps specified, autodetecting... ")
+    prefixes = ["en", "eth", "wl"]
+    f = open('/proc/net/dev')
+    lines = f.readlines()
+    f.close()
+    for l in lines:
+        for p in prefixes:
+            if l.startswith(p):
+                dev = l.split(":")[0]
+                print("found " + dev)
+                taps.append(NetworkTap('RX', dev))
+                taps.append(NetworkTap('TX', dev))
+                break
 
 def do_simple(feed):
     try:


### PR DESCRIPTION
That was my only grief with speedometer compared to tools
like iftop: Having to find out the network device name
beforehand.

This patch changes that: if no taps are specified on the
command line, go through /proc/net/dev, filter out the
interesting devices, and use those (both RX and TX for
each).